### PR TITLE
flush stdout after every line of output

### DIFF
--- a/shairport-sync-metadata-reader.c
+++ b/shairport-sync-metadata-reader.c
@@ -254,6 +254,9 @@ int main(void) {
           }
        }
      } 
+
+     // flush stdout, to be able to pipe it later
+     fflush(stdout);
    }
   return 0;
 }


### PR DESCRIPTION
Hey,
like I said in my previous pull request (mikebrady/shairport-sync#133) I started to use your metadata reader. I want to use it as an "event listener" especially for the events `pbeg`, `pend` and `pvol`.
Therefore I created a little wrapper script which reads every line from the metadata reader:

``` shell
shairport-sync-metadata-reader < /tmp/shairport-sync-metadata | while read LINE
do
 case "$LINE" in
   # on playback begin
   *pbeg*)
     ;; # code for playback start
   # on volume change
   *pvol*)
     ;; # code for volume change
   # on playback end
   *pend*)
     ;; # code for playback end
 esac
done
```

But than I noticed that the variable `$LINE` is always empty. Even if I run `shairport-sync-metadata-reader < /tmp/shairport-sync-metadata > file` to redirect all output to a file, the file stays empty.
If I run the reader normally (`shairport-sync-metadata-reader < /tmp/shairport-sync-metadata`), everything runs normal and I get an output on the console.

So I searched a bit on Google and found a hint that `fflush(stdout)` could solve the problem. I've added this line as the last line of the `while(1)` loop, so stdout gets flushed after the output of every line.

To cut a long story short: it works now!
So maybe you could add this to your official repository.

Thanks a lot
